### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -1,6 +1,8 @@
 # This starter workflow is for a CMake project running on a single platform. There is a different starter workflow if you need cross-platform coverage.
 # See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml
 name: PQCP Build and Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/openHiTLS/PQCP/security/code-scanning/1](https://github.com/openHiTLS/PQCP/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. In this case, the workflow only needs to check out code and upload artifacts, which only require `contents: read`. The best way to do this is to add a `permissions` block at the top level of the workflow (after the `name` field and before `on:`), so it applies to all jobs in the workflow. No changes to steps or jobs are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
